### PR TITLE
[Feat] #17 - 여러 개 음식 선호도 응답 저장하는 api 구현

### DIFF
--- a/src/preference/dto/create-preference.dto.ts
+++ b/src/preference/dto/create-preference.dto.ts
@@ -1,0 +1,9 @@
+export class CreatePreferenceDto {
+  foodId: string;
+  preference: 'Good' | 'Soso' | 'Bad';
+}
+
+export class SubmitPreferenceDto {
+  participantId: string;
+  preferences: CreatePreferenceDto[];
+}

--- a/src/preference/preference.controller.ts
+++ b/src/preference/preference.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 
 import { FoodRatingSummaryDto } from './dto/food-rating-summary';
 import { PreferenceService } from './preference.service';
 import { ResultFoodDto } from './dto/result-food.dto';
+import { SubmitPreferenceDto } from './dto/create-preference.dto';
 
 @Controller('preferences')
 export class PreferenceController {
@@ -16,5 +17,10 @@ export class PreferenceController {
   @Get('result/:roomId')
   async getResultMenu(@Param('roomId') roomId: string): Promise<ResultFoodDto> {
     return await this.preferenceService.getResultMenu(roomId);
+  }
+
+  @Post('submit')
+  async submitPreferences(@Body() dto: SubmitPreferenceDto) {
+    return await this.preferenceService.savePreferences(dto);
   }
 }

--- a/src/preference/preference.service.ts
+++ b/src/preference/preference.service.ts
@@ -4,11 +4,18 @@ import { Repository } from 'typeorm';
 import { FoodRatingSummaryDto } from './dto/food-rating-summary';
 import { ResultFoodDto } from './dto/result-food.dto';
 import { Food } from 'src/food/food.entity';
+import { SubmitPreferenceDto } from './dto/create-preference.dto';
+import { NotFoundException } from '@nestjs/common';
+import { Participants } from 'src/participants/participants.entity';
 
 export class PreferenceService {
   constructor(
     @InjectRepository(Preference)
     private readonly preferenceRepository: Repository<Preference>,
+    @InjectRepository(Food)
+    private readonly foodRepository: Repository<Food>,
+    @InjectRepository(Participants)
+    private readonly participantRepository: Repository<Participants>,
   ) {}
 
   async getReviewSummary(): Promise<FoodRatingSummaryDto[]> {
@@ -73,5 +80,31 @@ export class PreferenceService {
       description: randomTop.description,
       imgUrl: randomTop.imageUrl,
     };
+  }
+
+  async savePreferences(dto: SubmitPreferenceDto) {
+    const participant = await this.participantRepository.findOne({
+      where: { id: dto.participantId },
+    });
+    if (!participant) throw new NotFoundException('Participant not found');
+
+    const results: Preference[] = [];
+
+    for (const item of dto.preferences) {
+      const food = await this.foodRepository.findOne({
+        where: { id: item.foodId },
+      });
+      if (!food) continue;
+
+      const pref = this.preferenceRepository.create({
+        participant,
+        food,
+        rating: item.preference,
+      });
+
+      results.push(pref);
+    }
+
+    return await this.preferenceRepository.save(results);
   }
 }


### PR DESCRIPTION
## 📌 개요
> 해당 PR에서 어떤 작업을 했는지 요약해주세요.

- 여러 음식들 평가를 받아 한번에 저장하는 선호도 제출 api 

---

## ✅ 작업 내용 상세
> 주요 변경 사항을 자세히 적어주세요.

- [x] 기존 하나씩 제출하는 api와 별개로 한번에 제출가능, 프론트에서 모아다가 한번만 요청

---


## ✅ 참고 사항
> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.

- ex: 추후 리팩토링 예정인 부분
- ex: 임시 처리한 부분 있음 (`TODO:`로 표시)

---

## ✅ 관련 이슈
- 관련 이슈 번호: #17 
